### PR TITLE
Strip empty line at the end of code blocks

### DIFF
--- a/terratalk/terraform.py
+++ b/terratalk/terraform.py
@@ -29,4 +29,4 @@ class Terraform:
                 plan_output += "\n"
             plan_output += ''.join(m) + "\n"
 
-        return plan_output
+        return plan_output.rstrip()


### PR DESCRIPTION
There was always an empty line at the end of the comment which made them higher than necessary.